### PR TITLE
Define for @:native('Reselect')

### DIFF
--- a/src/reselect/Reselect.hx
+++ b/src/reselect/Reselect.hx
@@ -9,7 +9,11 @@ typedef StateAndMaybePropsSelector<TState, TProps, T> = TState -> ?TProps -> T;
 typedef StateAndPropsSelector<TState, TProps, T> = EitherType<TState -> TProps -> T, StateAndMaybePropsSelector<TState, TProps, T>>;
 typedef Selector<TState, TProps, T> = EitherType<StateSelector<TState, T>, StateAndPropsSelector<TState, TProps, T>>;
 
+#if reselect_global 
+@:native('Reselect')
+#else
 @:jsRequire('reselect')
+#end
 @:build(reselect.ReselectMacro.buildCreateSelector())
 extern class Reselect {
 	public static function createSelector(selectors:Array<Function>, resultFunc:Function):Function;


### PR DESCRIPTION
Added a compilation condition to make it possible to load Reselect library in a html script tag by using -D reselect_global.